### PR TITLE
feat: show start/end times in week overview

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -1736,7 +1736,25 @@ func (m Model) renderWeekContent() string {
 		}
 		b.WriteString(headerLine + "\n")
 
-		// Per-project breakdown.
+		// Start / end time sub-line (only shown when at least one is set).
+		if hasRec && (rec.StartTime != "" || rec.EndTime != "") {
+			start := rec.StartTime
+			end := rec.EndTime
+			startStr := dayViewValueStyle.Render(start)
+			if start == "" {
+				startStr = dayViewMutedStyle.Render("—")
+			}
+			endStr := dayViewValueStyle.Render(end)
+			if end == "" {
+				endStr = dayViewMutedStyle.Render("—")
+			}
+			timeLine := "  " + dayViewLabelStyle.Render("Start:") + " " + startStr +
+				"   " + dayViewLabelStyle.Render("End:") + " " + endStr
+			if dur, ok := rec.DayDuration(); ok {
+				timeLine += "   " + dayViewMutedStyle.Render("("+journal.FormatDuration(dur)+")")
+			}
+			b.WriteString(timeLine + "\n")
+		}
 		if hasRec && len(rec.Entries) > 0 {
 			type projGroup struct {
 				name   string


### PR DESCRIPTION
## Summary

Adds start and end time display to each day row in the weekly overview.

## Behaviour

- When a day has at least one of start time or end time recorded, a sub-line is shown beneath the day header:
  ```
  Mon  03 Feb 2026  ·  6h work  ·  30m breaks
    Start: 09:00   End: 17:30   (8h 30m)
  ```
- The day duration `(end - start)` is shown in parentheses when both times are present.
- If only one time is set, the other displays as `—`.
- Days with neither time recorded keep the existing compact single-line layout (no extra whitespace added).

## Change

Single targeted edit in `ui/model.go → renderWeekContent()` — ~19 lines added.